### PR TITLE
Fix README installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The python code was covered above, so for the sake of learning, this Getting-Sta
   git clone https://github.com/KeithG33/ChessBot-Battleground.git
   cd ChessBot-Battleground
   pip install -r requirements.txt
- pip install -e .
+  pip install -e .
 
   # Or install via pip 
   pip install git+https://github.com/KeithG33/ChessBot-Battleground.git

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The python code was covered above, so for the sake of learning, this Getting-Sta
   git clone https://github.com/KeithG33/ChessBot-Battleground.git
   cd ChessBot-Battleground
   pip install -r requirements.txt
-  pip install e .  
+ pip install -e .
 
   # Or install via pip 
   pip install git+https://github.com/KeithG33/ChessBot-Battleground.git


### PR DESCRIPTION
## Summary
- fix editable install command in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684cf42790248329bccac886c186606b