### PR TITLE
Fix scoring docstring

### DIFF
--- a/chessbot/inference/inference.py
+++ b/chessbot/inference/inference.py
@@ -9,8 +9,8 @@ from chessbot.mcts import MonteCarloTreeSearch
 
 def score_function(outcome, perspective) -> float | int:
     """
-    Return 1 of white won, -1 if white lost, 0 for draw --> perspective=chess.WHITE
-    Return 1 of black won, -1 if black lost, 0 for draw --> perspective=chess.BLACK
+    Return 1 if white won, -1 if white lost, and 0.5 for a draw --> perspective=chess.WHITE
+    Return 1 if black won, -1 if black lost, and 0.5 for a draw --> perspective=chess.BLACK
     """
     if outcome == 0:
         return 0.5


### PR DESCRIPTION
## Summary
- clarify that draw returns 0.5 in `score_function`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684d0415da308329a2ff2db29378fc62