### PR TITLE
Fix scheduler setup in trainer

### DIFF
--- a/chessbot/train/trainer.py
+++ b/chessbot/train/trainer.py
@@ -145,10 +145,14 @@ class BaseChessTrainer:
                 self.cfg.train.scheduler_iters,
                 self.cfg.train.min_lr,
             )
+        else:
+            scheduler = None
+
+        self.scheduler = scheduler
 
         if self.scheduler is not None and self.cfg.train.warmup_iters > 0:
             self.scheduler = WarmupLR(
-                scheduler,
+                self.scheduler,
                 init_lr=self.cfg.train.warmup_lr,
                 num_warmup=self.cfg.train.warmup_iters,
                 warmup_strategy=self.cfg.train.warmup_strategy,


### PR DESCRIPTION
## Summary
- fix scheduler not assigned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch', 'omegaconf')*

------
https://chatgpt.com/codex/tasks/task_e_684d0284df348329910456418fb70bbb