### PR TITLE
Add HF weight file naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Or if your model is registered as "your_chessbot", using the `chessbot` cli tool
 # For options and help:
 chessbot evaluate --help
 
-chessbot evaluate "your_chessbot" \ 
+  chessbot evaluate "your_chessbot" \
                   --model-dir path/to/dir \
                   --model-weights path/to/weights.pt \
                   --data-dir path/to/dataset \
@@ -272,7 +272,12 @@ chessbot play --help
 chessbot play "your_chessbot" \
               --model-dir /path/to/dir \
               --model-weights /path/to/weights.pt
+
+# Or load weights directly from HuggingFace
+chessbot play "swin_chessbot" \
+              --model-weights KeithG33/swin_chessbot
 ```
+The library expects the weights file on HuggingFace to be named `model.pt`.
 <div align="center">
 <img src="assets/battleground.png" style="width: 70%; height: auto;">  
   <p><em> Punishing a beautiful queen sac from a randomly initialized model ;)</em></p>

--- a/chessbot/mcts/train_mcts.py
+++ b/chessbot/mcts/train_mcts.py
@@ -26,7 +26,7 @@ class Config:
 
     # Optional pretrained weights
     MODEL_WEIGHTS = (
-        '/home/kage/chess_workspace/ChessBot-Battleground/models/sgu_chessbot/2025-02-19_18-51-experiment/model_latest/pytorch_model.bin'
+        '/home/kage/chess_workspace/ChessBot-Battleground/models/sgu_chessbot/2025-02-19_18-51-experiment/model_latest/model.pt'
     )
 
     # Training

--- a/chessbot/models/base.py
+++ b/chessbot/models/base.py
@@ -37,6 +37,17 @@ class BaseChessBot(nn.Module):
         weights = align_state_dict(torch.load(path, weights_only=True))
         self.load_state_dict(weights)
 
+    def load_hf_weights(self, repo_id: str, filename: str = "model.pt") -> None:
+        """Download weights from the HuggingFace Hub and load them."""
+        from huggingface_hub import hf_hub_download
+
+        try:
+            weights_path = hf_hub_download(repo_id=repo_id, filename=filename)
+        except Exception as e:
+            raise RuntimeError(f"Unable to download weights from {repo_id}: {e}") from e
+
+        self.load_weights(weights_path)
+
     def get_current_device(self):
         """Get the current device of the model"""
         return next(self.parameters()).device

--- a/models/example_chessbot/infer.py
+++ b/models/example_chessbot/infer.py
@@ -2,7 +2,7 @@ from chessbot.inference import selfplay, duel
 from simple_chessbot import SimpleChessBot
 
 model = SimpleChessBot(hidden_dim=512)
-# model.load_state_dict(torch.load('pytorch_model.bin'))
+# model.load_state_dict(torch.load('model.pt'))
 
 outcome = selfplay(
   model, 

--- a/tutorials/tutorial_usage_and_tips.md
+++ b/tutorials/tutorial_usage_and_tips.md
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     dataset_dir = DEFAULT_DATASET_DIR
     model = SimpleChessBot(hidden_dim=512)
     # Need to train to get weights
-    # model.load_weights('models/example_chessbot/output/model_best/pytorch_model.bin')
+    # model.load_weights('models/example_chessbot/output/model_best/model.pt')
     evaluate_model(
         model,
         dataset_dir=DEFAULT_DATASET_DIR,
@@ -211,8 +211,8 @@ if __name__ == "__main__":
 
 #### Using The CLI
 ```bash
-chessbot evaluate "simple_chessbot" \ 
-                  --model-weights models/example_chessbot/output/model_best/pytorch_model.bin \
+chessbot evaluate "simple_chessbot" \
+                  --model-weights models/example_chessbot/output/model_best/model.pt \
                   --batch-sz 3072 \
                   --num-threads 8 \
                   --num_chunks 0
@@ -234,7 +234,7 @@ from chessbot.inference import selfplay
 from simple_chessbot import SimpleChessBot
 
 model = SimpleChessBot(hidden_dim=512)
-# model.load_state_dict(torch.load('pytorch_model.bin'))
+# model.load_state_dict(torch.load('model.pt'))
 
 outcome = selfplay(
   model, 


### PR DESCRIPTION
## Summary
- simplify HuggingFace weight download logic
- expect weights to be stored as `model.pt`
- document new file name in README and tutorials

## Testing
- `pip install -q -r requirements.txt` *(failed: no output)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_686077a10c4883298d02f8c75a76cfcf