### PR TITLE
Improve chessbot gameplay commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Or load it like this:
 ```python
 from chessbot.models import MODEL_REGISTRY
 model = MODEL_REGISTRY.load_model('simple_chessbot')
+
+# Load and automatically apply weights
+model = MODEL_REGISTRY.load_with_weights('simple_chessbot', 'path/or/hf_repo')
 ```
 
 ## 🧠 Training
@@ -176,7 +179,7 @@ Take your models to the battleground!
 The library depends on an **Adversarial Gym Environment** designed for two-player turn-based games, that can be used to visualize model inference. Check out the functions in [`chessbot.inference`](chessbot/inference/):
 
 ```python
-from chessbot.inference import selfplay, duel
+from chessbot.inference import selfplay, play_match
 
 # Selfplay. Returns value in [-1,0,1] for white's outcome
 model1  = YourChessBot()
@@ -184,7 +187,7 @@ outcome = selfplay(model1, visualize=True)
 
 # Match between two models, use MCTS. Returns (score1,score2)
 model2 = YourChessBot()
-scores = duel(model1, model2, best_of=11, search=True, visualize=True)
+scores = play_match(model1, model2, best_of=11, search=True, visualize=True)
 ```
 
 Use the search flag to harness **Monte Carlo Tree Search (MCTS)** for search during inference. *MCTS training code coming soon!* The [Chess Battle GIF](#chess-battle-gif) at the beginning is an example of visualizing the game with the Chess-env, and using MCTS for test-time powered inference. 
@@ -307,6 +310,15 @@ chessbot play "your_chessbot" \
 # Or load weights directly from HuggingFace
 chessbot play "swin_chessbot" \
               --model-weights KeithG33/swin_chessbot
+```
+
+```bash
+# Selfplay or battle two models
+chessbot selfplay "swin_chessbot" --model-weights KeithG33/swin_chessbot
+
+chessbot play-match "swin_chessbot" "simple_chessbot" \
+               --player1-weights KeithG33/swin_chessbot \
+               --player2-weights /path/to/simple_weights.pt
 ```
 
 <div align="center">

--- a/chessbot/cli.py
+++ b/chessbot/cli.py
@@ -6,6 +6,7 @@ import typer
 
 from chessbot.data.download import download as download_fn
 from chessbot.inference.evaluate import evaluate_model
+from chessbot.inference import selfplay as selfplay_fn, play_game as play_game_fn, play_match as play_match_fn
 from chessbot.train.trainer import train_fn_hf, train_fn_local
 from chessbot.common import DEFAULT_DATASET_DIR, DEFAULT_MODEL_DIR
 from chessbot.models import align_state_dict
@@ -173,6 +174,116 @@ def play(
         load_weights(model, model_weights, hf_filename)
 
     play_fn(model, port)
+
+
+@app.command()
+def selfplay(
+    model_name: str = typer.Argument(..., help="Name of the model to load"),
+    model_dir: str = typer.Option(None, "--model-dir", help="Directory with model definitions"),
+    model_weights: str = typer.Option(None, "--model-weights", "-w", help="Path to model weights"),
+    hf_filename: str = typer.Option(
+        "pytorch_model.bin",
+        "--model-filename",
+        "-f",
+        help="Filename of the model weights to load (default: pytorch_model.bin)",
+    ),
+    model_args: List[str] = typer.Option(None, "--model-arg", "-a", help="Additional positional arguments for the model's constructor. This option can be used multiple times."),
+    model_kwargs: str = typer.Option("{}", "--model-kwargs", "-k", help="JSON string of extra keyword arguments for the model's constructor"),
+    search: bool = typer.Option(False, "--search", "-s", help="Use MCTS search"),
+    num_sims: int = typer.Option(250, "--num-sims", help="Number of MCTS simulations"),
+    visualize: bool = typer.Option(False, "--visualize", "-v", help="Visualize the game"),
+    sample: bool = typer.Option(False, "--sample", help="Sample from the policy distribution"),
+):
+    """Run a selfplay game with a model."""
+    model = find_and_load_from_register(model_name, model_dir, model_args, model_kwargs)
+    if model_weights:
+        load_weights(model, model_weights, hf_filename)
+    outcome = selfplay_fn(model, search=search, num_sims=num_sims, visualize=visualize, sample=sample)
+    typer.echo(f"Selfplay outcome (white perspective): {outcome}")
+
+
+@app.command(name="play-match")
+def play_match(
+    player1_name: str = typer.Argument(..., help="Model name for player 1"),
+    player2_name: str = typer.Argument(..., help="Model name for player 2"),
+    player1_dir: str = typer.Option(None, "--player1-dir", help="Directory with player1 model"),
+    player2_dir: str = typer.Option(None, "--player2-dir", help="Directory with player2 model"),
+    player1_weights: str = typer.Option(None, "--player1-weights", help="Weights path or HF repo for player1"),
+    player2_weights: str = typer.Option(None, "--player2-weights", help="Weights path or HF repo for player2"),
+    hf_filename: str = typer.Option(
+        "pytorch_model.bin",
+        "--model-filename",
+        "-f",
+        help="Filename of the model weights to load (default: pytorch_model.bin)",
+    ),
+    player1_args: List[str] = typer.Option(None, "--player1-arg", help="Positional args for player1 model", show_default=False),
+    player1_kwargs: str = typer.Option("{}", "--player1-kwargs", help="JSON kwargs for player1 model"),
+    player2_args: List[str] = typer.Option(None, "--player2-arg", help="Positional args for player2 model", show_default=False),
+    player2_kwargs: str = typer.Option("{}", "--player2-kwargs", help="JSON kwargs for player2 model"),
+    best_of: int = typer.Option(7, "--best-of", "-b", help="Number of games"),
+    search: bool = typer.Option(False, "--search", "-s", help="Use MCTS search"),
+    num_sims: int = typer.Option(250, "--num-sims", help="Number of MCTS simulations"),
+    visualize: bool = typer.Option(False, "--visualize", "-v", help="Visualize games"),
+    sample: bool = typer.Option(False, "--sample", help="Sample from the policy distribution"),
+):
+    """Play a match between two models."""
+    player1 = find_and_load_from_register(player1_name, player1_dir, player1_args, player1_kwargs)
+    player2 = find_and_load_from_register(player2_name, player2_dir, player2_args, player2_kwargs)
+    if player1_weights:
+        load_weights(player1, player1_weights, hf_filename)
+    if player2_weights:
+        load_weights(player2, player2_weights, hf_filename)
+    score1, score2 = play_match_fn(
+        player1,
+        player2,
+        best_of=best_of,
+        search=search,
+        num_sims=num_sims,
+        visualize=visualize,
+        sample=sample,
+    )
+    typer.echo(f"Final score: {score1} - {score2}")
+
+
+@app.command(name="play-game")
+def play_game(
+    player1_name: str = typer.Argument(..., help="Model name for player 1"),
+    player2_name: str = typer.Argument(..., help="Model name for player 2"),
+    player1_dir: str = typer.Option(None, "--player1-dir", help="Directory with player1 model"),
+    player2_dir: str = typer.Option(None, "--player2-dir", help="Directory with player2 model"),
+    player1_weights: str = typer.Option(None, "--player1-weights", help="Weights path or HF repo for player1"),
+    player2_weights: str = typer.Option(None, "--player2-weights", help="Weights path or HF repo for player2"),
+    hf_filename: str = typer.Option(
+        "pytorch_model.bin",
+        "--model-filename",
+        "-f",
+        help="Filename of the model weights to load (default: pytorch_model.bin)",
+    ),
+    player1_args: List[str] = typer.Option(None, "--player1-arg", help="Positional args for player1 model", show_default=False),
+    player1_kwargs: str = typer.Option("{}", "--player1-kwargs", help="JSON kwargs for player1 model"),
+    player2_args: List[str] = typer.Option(None, "--player2-arg", help="Positional args for player2 model", show_default=False),
+    player2_kwargs: str = typer.Option("{}", "--player2-kwargs", help="JSON kwargs for player2 model"),
+    search: bool = typer.Option(False, "--search", "-s", help="Use MCTS search"),
+    num_sims: int = typer.Option(250, "--num-sims", help="Number of MCTS simulations"),
+    visualize: bool = typer.Option(False, "--visualize", "-v", help="Visualize game"),
+    sample: bool = typer.Option(False, "--sample", help="Sample from the policy distribution"),
+):
+    """Play a single game between two models."""
+    player1 = find_and_load_from_register(player1_name, player1_dir, player1_args, player1_kwargs)
+    player2 = find_and_load_from_register(player2_name, player2_dir, player2_args, player2_kwargs)
+    if player1_weights:
+        load_weights(player1, player1_weights, hf_filename)
+    if player2_weights:
+        load_weights(player2, player2_weights, hf_filename)
+    outcome = play_game_fn(
+        player1,
+        player2,
+        search=search,
+        num_sims=num_sims,
+        visualize=visualize,
+        sample=sample,
+    )
+    typer.echo(f"Game outcome (1 white win, -1 black win, 0 draw): {outcome}")
 
 
 @app.command()

--- a/chessbot/inference/__init__.py
+++ b/chessbot/inference/__init__.py
@@ -1,6 +1,6 @@
 from .inference import (
     play_game,
-    duel,
+    play_match,
     selfplay,
 )
 

--- a/chessbot/inference/inference.py
+++ b/chessbot/inference/inference.py
@@ -25,7 +25,7 @@ def score_function(outcome, perspective) -> float | int:
     return 0
 
 
-def duel(
+def play_match(
     player1: BaseChessBot,
     player2: BaseChessBot,
     best_of=7,
@@ -35,14 +35,14 @@ def duel(
     sample=False,
 ) -> tuple[int, int]:
     """
-    Conducts a duel (best-of series) between two chess models and returns their respective scores.
+    Conduct a match (best-of series) between two chess models and return their respective scores.
 
     The final scores are computed with each win contributing +1, each loss -1, and draws contributing 0.
 
     Args:
         model1 (BaseChessModel): The first chess model.
         model2 (BaseChessModel): The second chess model.
-        best_of (int, optional): The number of games to be played in the duel. Defaults to 3.
+        best_of (int, optional): The number of games to be played in the match. Defaults to 3.
         search (bool, optional): If True, use MCTS for move selection in the games. Defaults to True.
         visualize (bool, optional): If True, render the games visually. Defaults to False.
         sample (bool, optional): If True, sample moves from the output distribution. Not relevant if search=True

--- a/chessbot/mcts/train_utils.py
+++ b/chessbot/mcts/train_utils.py
@@ -106,8 +106,8 @@ def convert_outcome(outcome, perspective):
     return 0
 
 
-def play_duel_game(args):
-    """ Set up and play a duel game between new and old model and return the score. """
+def play_match_game(args):
+    """Set up and play a match game between new and old model and return the score."""
     cfg, new_model_state, old_model_state, perspective, num_sims = args
     new_model = load_model(cfg, new_model_state, mode='eval')
     old_model = load_model(cfg, old_model_state, mode='eval')
@@ -121,8 +121,8 @@ def play_duel_game(args):
     return score
 
 
-def run_duel(cfg, new_model_path, old_model_path, num_rounds, file_lock, num_sims=100, num_processes=2):
-    """ Duel against the previous best model and return the score using parallel processes. """
+def run_play_match(cfg, new_model_path, old_model_path, num_rounds, file_lock, num_sims=100, num_processes=2):
+    """Play matches between the new and old model and return the score using parallel processes."""
     
     scores = []
     wins, losses, draws = 0, 0, 0
@@ -139,7 +139,7 @@ def run_duel(cfg, new_model_path, old_model_path, num_rounds, file_lock, num_sim
     args_list += [((cfg, new_model_state, old_model_state, chess.BLACK, num_sims)) for _ in range(num_rounds)]
 
     with Pool(processes=num_processes) as pool:
-        scores = pool.map(play_duel_game, args_list)
+        scores = pool.map(play_match_game, args_list)
 
     for score in scores:
         if   score == 0:    losses += 1
@@ -294,7 +294,7 @@ def run_training_epoch(shared_replay_buffer, cfg):
             }
         )
 
-    # Epoch done - save model for dueling, optimizer 
+    # Epoch done - save model for match evaluation, optimizer
     torch.save(model.state_dict(), cfg.MODEL_CURR_PATH)
     
     # Save optimizer and scheduler states for the next epoch.

--- a/chessbot/models/registry.py
+++ b/chessbot/models/registry.py
@@ -103,3 +103,29 @@ class ModelRegistry:
         if model_path:
             cls._load_models_from_path(model_path)
         return cls._load_model(model_name, *init_args, **init_kwargs)
+
+    @classmethod
+    def load_with_weights(
+        cls,
+        model_name: str,
+        weights_id: str,
+        model_path: str | None = None,
+        hf_filename: str = "pytorch_model.bin",
+        *init_args,
+        **init_kwargs,
+    ):
+        """Load a registered model and automatically load weights.
+
+        Args:
+            model_name: Name of the model to load.
+            weights_id: Local path or HuggingFace repo id for the weights.
+            model_path: Optional additional directory to search for model
+                registrations.
+            hf_filename: Name of the weight file on HuggingFace.
+        """
+        model = cls.load_model(model_name, model_path, *init_args, **init_kwargs)
+        if os.path.exists(weights_id):
+            model.load_weights(weights_id)
+        else:
+            model.load_hf_weights(weights_id, filename=hf_filename)
+        return model

--- a/models/example_chessbot/README.md
+++ b/models/example_chessbot/README.md
@@ -5,4 +5,4 @@ This repository contains an example implementation of a chess AI model for demon
 Check out the different scripts for usage examples:
 1. `train.py / train.sh` - training with python or cli
 2. `evaluate.py / evaluate.sh` - evaluation with python or cli
-3. `infer.py` - run selfplay or duels with your models
+3. `infer.py` - run selfplay or matches with your models

--- a/models/example_chessbot/infer.py
+++ b/models/example_chessbot/infer.py
@@ -1,4 +1,4 @@
-from chessbot.inference import selfplay, duel
+from chessbot.inference import selfplay, play_match
 from simple_chessbot import SimpleChessBot
 
 model = SimpleChessBot(hidden_dim=512)
@@ -11,7 +11,7 @@ outcome = selfplay(
   visualize=True # Display the game
 )
 
-scores = duel(
+scores = play_match(
   model,  # player1 model
   model,  # player2 model
   best_of=7,      # Best-of 

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -1,5 +1,5 @@
 from chessbot.models import MODEL_REGISTRY
-from chessbot.inference import selfplay, duel
+from chessbot.inference import selfplay, play_match
 
 # Run selfplay
 model1 = MODEL_REGISTRY.load_model("simple_chessbot")
@@ -7,4 +7,4 @@ outcome = selfplay(model1, search=True, visualize=False, sample=True) # 1 if whi
 
 # Play a match with two models, use MCTS
 model2 = MODEL_REGISTRY.load_model("simple_chessbot")
-scores = duel(model1, model2, best_of=3, search=True, visualize=True) # Returns (score1, score2)
+scores = play_match(model1, model2, best_of=3, search=True, visualize=True) # Returns (score1, score2)

--- a/tutorials/tutorial_usage_and_tips.md
+++ b/tutorials/tutorial_usage_and_tips.md
@@ -246,9 +246,9 @@ outcome = selfplay(
 
 The outcome will correspond to losing-drawing-winning with white.
 
-### ⚔️ Duel two models
+### ⚔️ Play a match between two models
 ```python
-from chessbot.inference import duel
+from chessbot.inference import play_match
 from simple_chessbot import SimpleChessBot
 
 p1 = SimpleChessBot(hidden_dim=512)
@@ -257,7 +257,7 @@ p1 = SimpleChessBot(hidden_dim=512)
 p2 = SimpleChessBot(hidden_dim=512)
 # p2.load_state_dict(torch.load('pytorch_model2.bin'))
 
-scores = duel(
+scores = play_match(
   p1, # player1 model
   p2, # player2 model
   best_of=7, # Best-of 
@@ -286,6 +286,18 @@ other hall-of-fame models in the [models/](../models/) directory using their Hug
 ```bash
 chessbot play "sgu_chessbot" \
               --model-weights KeithG33/sgu_chessbot \
+```
+
+You can also run automated games from the command line:
+
+```bash
+# Selfplay
+chessbot selfplay "sgu_chessbot" --model-weights KeithG33/sgu_chessbot --search
+
+# Best-of match
+chessbot play-match "sgu_chessbot" "simple_chessbot" \
+               --player1-weights KeithG33/sgu_chessbot \
+               --player2-weights /path/to/simple_weights.pt
 ```
 ## 💾 8. Generating Data
 


### PR DESCRIPTION
## Summary
- add `load_with_weights` helper to registry
- rename `duel` to `play_match`
- expose new `selfplay`, `play-match`, and `play-game` commands
- update example and tutorial docs
- document new CLI usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6869791c213883298b8033b1ebbcae54