### PR TITLE
Rename play-match to run-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Take your models to the battleground!
 The library depends on an **Adversarial Gym Environment** designed for two-player turn-based games, that can be used to visualize model inference. Check out the functions in [`chessbot.inference`](chessbot/inference/):
 
 ```python
-from chessbot.inference import selfplay, play_match
+from chessbot.inference import selfplay, run_match
 
 # Selfplay. Returns value in [-1,0,1] for white's outcome
 model1  = YourChessBot()
@@ -187,7 +187,7 @@ outcome = selfplay(model1, visualize=True)
 
 # Match between two models, use MCTS. Returns (score1,score2)
 model2 = YourChessBot()
-scores = play_match(model1, model2, best_of=11, search=True, visualize=True)
+scores = run_match(model1, model2, best_of=11, search=True, visualize=True)
 ```
 
 Use the search flag to harness **Monte Carlo Tree Search (MCTS)** for search during inference. *MCTS training code coming soon!* The [Chess Battle GIF](#chess-battle-gif) at the beginning is an example of visualizing the game with the Chess-env, and using MCTS for test-time powered inference. 

--- a/chessbot/inference/__init__.py
+++ b/chessbot/inference/__init__.py
@@ -1,6 +1,5 @@
 from .inference import (
-    play_game,
-    play_match,
+    run_match,
     selfplay,
 )
 

--- a/chessbot/inference/inference.py
+++ b/chessbot/inference/inference.py
@@ -25,14 +25,14 @@ def score_function(outcome, perspective) -> float | int:
     return 0
 
 
-def play_match(
+def run_match(
     player1: BaseChessBot,
     player2: BaseChessBot,
-    best_of=7,
-    search=False,
-    num_sims=250,
-    visualize=False,
-    sample=False,
+    best_of: int = 1,
+    search: bool = False,
+    num_sims: int = 250,
+    visualize: bool = True,
+    sample: bool = False,
 ) -> tuple[int, int]:
     """
     Conduct a match (best-of series) between two chess models and return their respective scores.
@@ -42,9 +42,9 @@ def play_match(
     Args:
         model1 (BaseChessModel): The first chess model.
         model2 (BaseChessModel): The second chess model.
-        best_of (int, optional): The number of games to be played in the match. Defaults to 3.
-        search (bool, optional): If True, use MCTS for move selection in the games. Defaults to True.
-        visualize (bool, optional): If True, render the games visually. Defaults to False.
+        best_of (int, optional): The number of games to be played in the match. Defaults to 1.
+        search (bool, optional): If True, use MCTS for move selection in the games. Defaults to False.
+        visualize (bool, optional): If True, render the games visually. Defaults to True.
         sample (bool, optional): If True, sample moves from the output distribution. Not relevant if search=True
 
     Returns:

--- a/models/example_chessbot/infer.py
+++ b/models/example_chessbot/infer.py
@@ -1,4 +1,4 @@
-from chessbot.inference import selfplay, play_match
+from chessbot.inference import selfplay, run_match
 from simple_chessbot import SimpleChessBot
 
 model = SimpleChessBot(hidden_dim=512)
@@ -11,7 +11,7 @@ outcome = selfplay(
   visualize=True # Display the game
 )
 
-scores = play_match(
+scores = run_match(
   model,  # player1 model
   model,  # player2 model
   best_of=7,      # Best-of 

--- a/tests/play_test.py
+++ b/tests/play_test.py
@@ -1,5 +1,5 @@
 from chessbot.models import MODEL_REGISTRY
-from chessbot.inference import selfplay, play_match
+from chessbot.inference import selfplay, run_match
 
 # Run selfplay
 model1 = MODEL_REGISTRY.load_model("simple_chessbot")
@@ -7,4 +7,4 @@ outcome = selfplay(model1, search=True, visualize=False, sample=True) # 1 if whi
 
 # Play a match with two models, use MCTS
 model2 = MODEL_REGISTRY.load_model("simple_chessbot")
-scores = play_match(model1, model2, best_of=3, search=True, visualize=True) # Returns (score1, score2)
+scores = run_match(model1, model2, best_of=3, search=True, visualize=True) # Returns (score1, score2)

--- a/tutorials/tutorial_usage_and_tips.md
+++ b/tutorials/tutorial_usage_and_tips.md
@@ -248,7 +248,7 @@ The outcome will correspond to losing-drawing-winning with white.
 
 ### ⚔️ Play a match between two models
 ```python
-from chessbot.inference import play_match
+from chessbot.inference import run_match
 from simple_chessbot import SimpleChessBot
 
 p1 = SimpleChessBot(hidden_dim=512)
@@ -257,7 +257,7 @@ p1 = SimpleChessBot(hidden_dim=512)
 p2 = SimpleChessBot(hidden_dim=512)
 # p2.load_state_dict(torch.load('pytorch_model2.bin'))
 
-scores = play_match(
+scores = run_match(
   p1, # player1 model
   p2, # player2 model
   best_of=7, # Best-of 


### PR DESCRIPTION
## Summary
- rename CLI `play-match` command to `run-match`
- remove `play-game` CLI command
- rename `play_match` to `run_match` and set visualization default
- update docs, examples and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch', ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_686988b4556483298070930d72c53d44